### PR TITLE
Fix check expiration for Carbon 3.0 diffInSeconds

### DIFF
--- a/src/Support/AttackBlocker.php
+++ b/src/Support/AttackBlocker.php
@@ -110,7 +110,7 @@ class AttackBlocker
     protected function checkExpiration()
     {
         $this->getEnabledItems()->each(function ($index, $type) {
-            if (($this->now()->diffInSeconds($this->record[$type]['lastRequestAt'])) <= ($this->getMaxSecondsForType($type))) {
+            if ($this->now()->diffInSeconds($this->record[$type]['lastRequestAt'], true) <= ($this->getMaxSecondsForType($type))) {
                 return $this->record;
             }
 
@@ -348,7 +348,9 @@ class AttackBlocker
      */
     private function now()
     {
-        Carbon::setTestNow();
+        if(app()->runningUnitTests()){
+            Carbon::setTestNow();
+        }
 
         return Carbon::now();
     }


### PR DESCRIPTION
In AttackBlocker.php:checkExpiration() I get for the lastRequestAt 2024-08-20 22:57:29 a minus value (for example -82) instead of a absolute value. In Carbon 3.0 the diffInSeconds is changed, when we add an extra parameter true, it will fix the problem and we get a positive value back.